### PR TITLE
Fix readme to use proper action path (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Sync up to CodeCommit
-        uses: afinkorea/sync-up-to-codecommit-action@v1
+        uses: hectorcoy/aws-codecommit-syncv2@master
         with:
           repository_name: test_repo
           aws_region: ap-northeast-2

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Sync up to CodeCommit
-        uses: hectorcoy/aws-codecommit-syncv2@master
+        uses: hectorcoy/aws-codecommit-syncv2@1.0.19
         with:
           repository_name: test_repo
           aws_region: ap-northeast-2


### PR DESCRIPTION
The readme example is wrong and outdated, it should be using `hectorcoy` namespace instead of the previous `afinkorea` namespace. It should also use the `@master` tag since there is no `@v1` in @hectorcoy's repo.